### PR TITLE
Fix FlightGear startup under Windows

### DIFF
--- a/FlightGear/fg_install_searcher.bat
+++ b/FlightGear/fg_install_searcher.bat
@@ -9,11 +9,11 @@ set /A increment=1
 set folder_name=0
 
 set "fg_search_path=%programfiles%"
-cd %fg_search_path%
+cd /d %fg_search_path%
 call:fgSearcher
 
 set "fg_search_path=%programfiles(x86)%"
-cd %fg_search_path%
+cd /d %fg_search_path%
 call:fgSearcher
 
 if ("%num_fg_versions%"=="0") (

--- a/FlightGear/runfg_IRIS.bat
+++ b/FlightGear/runfg_IRIS.bat
@@ -4,6 +4,6 @@ call fg_install_searcher.bat
 
 call fg_aircraft_path.bat
 
-cd %FG_PATH%
+cd /d %FG_PATH%
 
-.\\bin\fgfs --aircraft=IRIS --fdm=null --native-fdm=socket,in,30,localhost,5502,udp --native-ctrls=socket,out,30,127.0.0.1,5503,udp --fog-fastest --disable-clouds --start-date-lat=2004:06:01:09:00:00 --disable-sound --in-air --lat=37.6117 --lon=-122.3782 --altitude=7224 --heading=113 --offset-distance=4.72 --offset-azimuth=0
+.\\bin\fgfs --aircraft=IRIS --fdm=null --native-fdm=socket,in,30,localhost,5502,udp --native-ctrls=socket,out,30,127.0.0.1,5503,udp --fog-fastest --disable-clouds --start-date-lat=2004:06:01:09:00:00 --disable-sound --in-air --lat=37.6117 --lon=-122.3782 --altitude=7224 --heading=113 --offset-distance=4.72 --offset-azimuth=0 --enable-terrasync


### PR DESCRIPTION
The .bat scripts to start FlightGear under Windows only worked if they were executed from the same drive where FlightGear is installed (usually C:\). This update fixes the problem of FlightGear not loading if the start scripts are on a different drive. In addition, the FlightGear terrasync option has been added to visualise the environment as is already the case in the bash scripts.