### PR TITLE
Add control allocation parameter file for Minnie

### DIFF
--- a/LADAC_params/Minnie/caWls_params_Minnie.m
+++ b/LADAC_params/Minnie/caWls_params_Minnie.m
@@ -1,0 +1,19 @@
+% ** Parameters for wls control allocation (Minnie) **
+% 
+% See also:
+%   caWls_params_default.m
+
+% Disclaimer:
+%   SPDX-License-Identifier: GPL-3.0-only
+% 
+%   Copyright (C) 2020-2022 Yannic Beyer
+%   Copyright (C) 2024 TU Braunschweig, Institute of Flight Guidance
+% *************************************************************************
+
+% k is the number of control inputs
+% m is the number of pseudo control inputs
+
+param = loadParams( 'caWls_params_default' );
+
+% weighting mxm matrix of pseudo-control
+param.W_v = diag([30,30,0.01,300]);


### PR DESCRIPTION
This is required due to externalization of hard-coded parameters in lindiCopterAutoCreate.