### PR TITLE
Remove matrices from LindiCopter parameters struct

### DIFF
--- a/LADAC_params/Minnie/caWls_params_Minnie.m
+++ b/LADAC_params/Minnie/caWls_params_Minnie.m
@@ -16,4 +16,4 @@
 param = loadParams( 'caWls_params_default' );
 
 % weighting mxm matrix of pseudo-control
-param.W_v = diag([30,30,0.01,300]);
+param.W_v = [30; 30; 0.01; 300];

--- a/LADAC_params/Minnie/control/fmCopterLoiterIndi_params_Minnie.m
+++ b/LADAC_params/Minnie/control/fmCopterLoiterIndi_params_Minnie.m
@@ -20,7 +20,7 @@ param.cep = loadParams( 'indiCeProp_params_default' );
 param.ceb = loadParams( 'indiCeBody_params_default' );
 
 % control allocation
-param.ca = loadParams( 'control_allocation_wls_params_quadcopter' );
+param.ca = loadParams( 'caWls_params_default' );
 
 % sensor filter
 param.sflt = loadParams( 'indiSensFilt_params_Minnie' );

--- a/LADAC_params/shared/control_allocation_wls_params_quadcopter.m
+++ b/LADAC_params/shared/control_allocation_wls_params_quadcopter.m
@@ -10,20 +10,23 @@
 % k is the number of control inputs
 % m is the number of pseudo control inputs
 
-% minimum control input kx1 vector
-param.u_min = 0.1*ones(4,1);
-% maximum control input kx1 vector
-param.u_max = ones(4,1);
-% desired control input kx1 vector
-param.u_d = 0.1*ones(4,1);
+% minimum control input (used for k control inputs)
+param.u_min = 0.1;
 
-% weighting mxm matrix of pseudo-control
-param.W_v = diag([10,10,0.01,1]);
-% weighting kxk matrix of the control input vector
-param.W_u = eye(4);
+% maximum control input (used for k control inputs)
+param.u_max = 1;
+
+% desired control input (used for k control inputs)
+param.u_d = 0.1;
+
+% weighting mx1 array of pseudo-control (used as mxm matrix)
+param.W_v = [10; 10; 0.01; 1];
+
+% weighting kx1 array of the control input vector (used as kxk matrix)
+param.W_u = ones(4,1);
+
 % weighting of pseudo-control vs. control input (scalar)
 param.gamma = 1000;
-% initial working set mx1 vector
-param.W = zeros(4,1);
+
 % maximum number of iterations (scalar)
 param.i_max = 100;


### PR DESCRIPTION
Converted matrices to arrays in the control allocation field (ca) of the LindiCopter parameters struct. This is required to be compatible with the ArduPilot parameter ecosystem.

This is a breaking change that introduces incompatibility with the old LindiCopter parameters struct format.