### PR TITLE
FlightGear: Simplify Windows script and ensure compatibility with FlightGear 2024.1 and later

### DIFF
--- a/FlightGear/fg_aircraft_path.bat
+++ b/FlightGear/fg_aircraft_path.bat
@@ -1,5 +1,0 @@
-@echo off
-
-set scriptpath=%~dp0
-set FG_AIRCRAFT=%FG_AIRCRAFT%;%scriptpath%../FlightGear
-

--- a/FlightGear/fg_install_searcher.bat
+++ b/FlightGear/fg_install_searcher.bat
@@ -7,13 +7,8 @@ set fg_versions_nums=0 1 2 3 4
 set /A num_fg_versions=0
 set folder_name=0
 
-set "fg_search_path=%programfiles%"
-cd /d %fg_search_path%
-call :fgSearcher
-
-set "fg_search_path=%programfiles(x86)%"
-cd /d %fg_search_path%
-call :fgSearcher
+call :fgSearcher "%ProgramFiles%"
+call :fgSearcher "%ProgramFiles(x86)%"
 
 if %num_fg_versions%==0 (
 	echo Error: FlightGear was NOT found!
@@ -23,12 +18,12 @@ if %num_fg_versions%==0 (
 
 echo Found the following FlightGear version(s):
 for /l %%i in (1,1,%num_fg_versions%) do (
-	echo !fg_versions_nums[%%i]!  !fg_versions_list[%%i]!
+    echo %%i  !fg_versions_list[%%i]!
 )
 
 set choice=1
 if %num_fg_versions% gtr 1 (
-	set /p choice="Please select one of the above options [1/2/...]: "
+    set /p choice="Please select one of the above options [1-%num_fg_versions%]: "
 )
 
 set folder_name=!fg_versions_list[%choice%]!
@@ -39,14 +34,18 @@ if exist "!fg_path!\data" (
     set "fg_root=!fg_path!\data"
 ) else (
     set "found="
-    for /d %%D in ("%userprofile%\FlightGear\Downloads\fgdata_*") do (
-        if not defined found (
-            set "fg_root=%%D"
-            set "found=1"
-        )
+    for /f "usebackq tokens=*" %%A in (`"!fg_path!\bin\fgfs" --version 2^>^&1`) do (
+        set "line=%%A"
+        echo !line! | findstr /b "FG_ROOT=" >nul
+        if !errorlevel! == 0 (
+            for /f "tokens=2 delims==" %%B in ("!line!") do (
+                set "fg_root=%%B"
+                set "found=1"
+            )
+        ) 
     )
     if not defined found (
-        echo(
+        echo.
         echo Error: FlightGear data folder not found
         echo Please ensure that the FlightGear data folder exists in the expected location.
         echo You can download the data from within the FlighGear launcher or from the official FlightGear website: https://www.flightgear.org/download/
@@ -56,9 +55,10 @@ if exist "!fg_path!\data" (
     )
 )
 
+echo.
 echo FlightGear data folder found at !fg_root!
-echo Starting !fg_versions_list[%choice%]! from %fg_path%
-echo(
+echo Starting !fg_versions_list[%choice%]! from !fg_path!
+echo.
 
 endlocal & (
 	set "FG_PATH=%fg_path%"
@@ -67,13 +67,14 @@ endlocal & (
 exit /b 0
 
 :fgSearcher
-for /d %%P in ("*") do (
-set folder_name=%%P
-if "!folder_name:~0,10!"=="FlightGear" (
-	set /a num_fg_versions+=1
-	set fg_versions_list[!num_fg_versions!]=%%P
-	set fg_versions_nums[!num_fg_versions!]=!num_fg_versions!
-	set "fg_parent_dir_list[!num_fg_versions!]=%fg_search_path%"
-	)
+set "fg_search_path=%~1"
+for /d %%P in ("%fg_search_path%\*") do (
+    set folder_name=%%~nxP
+    if "!folder_name:~0,10!"=="FlightGear" (
+        set /a num_fg_versions+=1
+        set "fg_versions_list[!num_fg_versions!]=!folder_name!"
+        set "fg_versions_nums[!num_fg_versions!]=!num_fg_versions!"
+        set "fg_parent_dir_list[!num_fg_versions!]=%fg_search_path%"
+    )
 )
 goto :eof

--- a/FlightGear/fg_install_searcher.bat
+++ b/FlightGear/fg_install_searcher.bat
@@ -5,58 +5,75 @@ set fg_versions_list=0 1 2 3 4
 set fg_parent_dir_list=0 1 2 3 4
 set fg_versions_nums=0 1 2 3 4
 set /A num_fg_versions=0
-set /A increment=1
 set folder_name=0
 
 set "fg_search_path=%programfiles%"
 cd /d %fg_search_path%
-call:fgSearcher
+call :fgSearcher
 
 set "fg_search_path=%programfiles(x86)%"
 cd /d %fg_search_path%
-call:fgSearcher
+call :fgSearcher
 
-if ("%num_fg_versions%"=="0") (
+if %num_fg_versions%==0 (
 	echo Error: FlightGear was NOT found!
 	pause
+    exit /b 1
 )
 
 echo Found the following FlightGear version(s):
-
 for /l %%i in (1,1,%num_fg_versions%) do (
 	echo !fg_versions_nums[%%i]!  !fg_versions_list[%%i]!
 )
 
 set choice=1
 if %num_fg_versions% gtr 1 (
-	set /p choice="Please select one of the above options [1/2/...]:"
+	set /p choice="Please select one of the above options [1/2/...]: "
 )
-
 
 set folder_name=!fg_versions_list[%choice%]!
 set parent_folder_name=!fg_parent_dir_list[%choice%]!
+set fg_path=%parent_folder_name%\%folder_name%
 
-set fg_path=%parent_folder_name%/%folder_name%
+if exist "!fg_path!\data" (
+    set "fg_root=!fg_path!\data"
+) else (
+    set "found="
+    for /d %%D in ("%userprofile%\FlightGear\Downloads\fgdata_*") do (
+        if not defined found (
+            set "fg_root=%%D"
+            set "found=1"
+        )
+    )
+    if not defined found (
+        echo(
+        echo Error: FlightGear data folder not found
+        echo Please ensure that the FlightGear data folder exists in the expected location.
+        echo You can download the data from within the FlighGear launcher or from the official FlightGear website: https://www.flightgear.org/download/
+        echo After downloading, place the data folder in the appropriate directory and try running this script again.
+        pause
+        exit /b 1
+    )
+)
 
-echo Starting FlightGear from: %fg_path%
-
-set fg_root=%fg_path%/data
+echo FlightGear data folder found at !fg_root!
+echo Starting !fg_versions_list[%choice%]! from %fg_path%
+echo(
 
 endlocal & (
 	set "FG_PATH=%fg_path%"
 	set "FG_ROOT=%fg_root%"
 )
-
-
+exit /b 0
 
 :fgSearcher
 for /d %%P in ("*") do (
 set folder_name=%%P
 if "!folder_name:~0,10!"=="FlightGear" (
-	set /a num_fg_versions=!num_fg_versions!+%increment%
+	set /a num_fg_versions+=1
 	set fg_versions_list[!num_fg_versions!]=%%P
 	set fg_versions_nums[!num_fg_versions!]=!num_fg_versions!
 	set "fg_parent_dir_list[!num_fg_versions!]=%fg_search_path%"
 	)
 )
-goto:eof
+goto :eof

--- a/FlightGear/runfg_Dummy-RC-Airplane.bat
+++ b/FlightGear/runfg_Dummy-RC-Airplane.bat
@@ -2,8 +2,22 @@
 
 call fg_install_searcher.bat
 
-call fg_aircraft_path.bat
-
-cd %FG_PATH%
-
-.\\bin\fgfs --aircraft=DummyRcAirplane --fdm=null --native-fdm=socket,in,30,localhost,5502,udp --native-ctrls=socket,out,30,127.0.0.1,5503,udp --fog-fastest --disable-clouds --start-date-lat=2004:06:01:09:00:00 --disable-sound --in-air --enable-freeze --lat=37.6117 --lon=-122.3782 --altitude=7224 --heading=113 --offset-distance=4.72 --offset-azimuth=0
+"%FG_PATH%\bin\fgfs" ^
+ --fg-aircraft=%~dp0 ^
+ --aircraft=DummyRcAirplane ^
+ --fdm=null ^
+ --native-fdm=socket,in,30,localhost,5502,udp ^
+ --native-ctrls=socket,out,30,127.0.0.1,5503,udp ^
+ --fog-fastest ^
+ --disable-clouds ^
+ --start-date-lat=2004:06:01:09:00:00 ^
+ --disable-sound ^
+ --in-air ^
+ --enable-freeze ^
+ --lat=37.6117 ^
+ --lon=-122.3782 ^
+ --altitude=7224 ^
+ --heading=113 ^
+ --offset-distance=4.72 ^
+ --offset-azimuth=0 ^
+ --enable-terrasync

--- a/FlightGear/runfg_IRIS.bat
+++ b/FlightGear/runfg_IRIS.bat
@@ -2,8 +2,21 @@
 
 call fg_install_searcher.bat
 
-call fg_aircraft_path.bat
-
-cd /d %FG_PATH%
-
-.\\bin\fgfs --aircraft=IRIS --fdm=null --native-fdm=socket,in,30,localhost,5502,udp --native-ctrls=socket,out,30,127.0.0.1,5503,udp --fog-fastest --disable-clouds --start-date-lat=2004:06:01:09:00:00 --disable-sound --in-air --lat=37.6117 --lon=-122.3782 --altitude=7224 --heading=113 --offset-distance=4.72 --offset-azimuth=0 --enable-terrasync
+"%FG_PATH%\bin\fgfs" ^
+ --fg-aircraft=%~dp0 ^
+ --aircraft=IRIS ^
+ --fdm=null ^
+ --native-fdm=socket,in,30,localhost,5502,udp ^
+ --native-ctrls=socket,out,30,127.0.0.1,5503,udp ^
+ --fog-fastest ^
+ --disable-clouds ^
+ --start-date-lat=2004:06:01:09:00:00 ^
+ --disable-sound ^
+ --in-air ^
+ --lat=37.6117 ^
+ --lon=-122.3782 ^
+ --altitude=7224 ^
+ --heading=113 ^
+ --offset-distance=4.72 ^
+ --offset-azimuth=0 ^
+ --enable-terrasync


### PR DESCRIPTION
- Omit fg_aircraft_path.bat (now included in runfg_x.bat)
- Improve formatting in runfg_x.bat
- Add a search for the FlightGear data folder (from 2024.1 onwards in %userprofile%\FlightGear)
- Syntax-fixes in batchfiles

[Tested with 2020.3.1, 2020.3.19 and 2024.1.1]